### PR TITLE
fix: Search bar is sticky at the top

### DIFF
--- a/components/server/server-sidebar.tsx
+++ b/components/server/server-sidebar.tsx
@@ -63,7 +63,7 @@ const ServerSidebar = async ({
     <div className="flex flex-col h-full text-primary w-full dark:bg-[#2b2d31] bg-[#f2f3f5]">
       <ServerHeader server={server} role={myRole} members={memberTemp} />
       <ScrollArea className="flex-1 px-3">
-        <div className="mt-2">
+        <div className="mt-2 sticky top-0 dark:bg-[#2b2d31] bg-[#f2f3f5]">
           <ServerSearch
             data={[
               {


### PR DESCRIPTION
Search bar is not scrollable with other elements.

![Screenshot (228)](https://github.com/Yeasir0032/Discord-Clone/assets/113261155/c8eabe49-c94b-4d40-b4ee-45aeeb82eb80)


